### PR TITLE
Removed design for extension rule in checkstyle.

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -172,7 +172,6 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension"/>
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>


### PR DESCRIPTION
rationale:
when a method is not abstract or has an empty body, it should be final according to checkstyle.
However final methods can not be stubbed.
We think the possibility to stub is more important than this checkstyle rule; even though the though behind the rule, design for extension, is a good thought.

See: http://checkstyle.sourceforge.net/config_design.html#DesignForExtension