### PR TITLE
cobertura report for modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,14 +41,24 @@ allprojects {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
     }
-
-
 }
 
 project(":core") {
     apply plugin: "java"
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coberturaVersion = '2.1.1'
+        coverageFormats = ['xml', 'html']
+        coverageIgnoreTrivial = true
+        coverageReportDir = file("${buildDir}/reports/cobertura")
 
-    apply from: "${rootProject.rootDir}/gradle/plugins.gradle"
+        rootProject.subprojects.each {
+            coverageDirs << file("${it.name}/build/classes/main")
+        }
+    }
+
+    test.finalizedBy(project.tasks.cobertura)
+//    apply from: "${rootProject.rootDir}/gradle/plugins.gradle"
 
     dependencies {
         compile project(":client")
@@ -65,6 +75,19 @@ project(":core") {
 
 project(":desktop") {
     apply plugin: "java"
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coberturaVersion = '2.1.1'
+        coverageFormats = ['xml', 'html']
+        coverageIgnoreTrivial = true
+        coverageReportDir = file("${buildDir}/reports/cobertura")
+
+        rootProject.subprojects.each {
+            coverageDirs << file("${it.name}/build/classes/main")
+        }
+    }
+
+    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":core")
@@ -77,11 +100,25 @@ project(":desktop") {
 
 project(":server") {
     apply plugin: "java"
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coberturaVersion = '2.1.1'
+        coverageFormats = ['xml', 'html']
+        coverageIgnoreTrivial = true
+        coverageReportDir = file("${buildDir}/reports/cobertura")
+
+        rootProject.subprojects.each {
+            coverageDirs << file("${it.name}/build/classes/main")
+        }
+    }
+
+    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":data_structures")
         compile "org.xerial:sqlite-jdbc:3.8.6"
         compile "org.sqldroid:sqldroid:1.0.3"
+        compile "org.slf4j:slf4j-simple:$slf4jVersion"
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.mockito:mockito-core:$mockitoVersion"
@@ -90,6 +127,19 @@ project(":server") {
 
 project(":client") {
     apply plugin: "java"
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coberturaVersion = '2.1.1'
+        coverageFormats = ['xml', 'html']
+        coverageIgnoreTrivial = true
+        coverageReportDir = file("${buildDir}/reports/cobertura")
+
+        rootProject.subprojects.each {
+            coverageDirs << file("${it.name}/build/classes/main")
+        }
+    }
+
+    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":server")
@@ -99,12 +149,28 @@ project(":client") {
     }
 }
 
+
+
 project(":data_structures") {
     apply plugin: "java"
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coberturaVersion = '2.1.1'
+        coverageFormats = ['xml', 'html']
+        coverageIgnoreTrivial = true
+        coverageReportDir = file("${buildDir}/reports/cobertura")
+
+        rootProject.subprojects.each {
+            coverageDirs << file("${it.name}/build/classes/main")
+        }
+    }
+
+    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         testCompile "junit:junit:$junitVersion"
         testCompile "org.mockito:mockito-core:$mockitoVersion"
+        compile "org.slf4j:slf4j-simple:$slf4jVersion"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,22 +41,16 @@ allprojects {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://oss.sonatype.org/content/repositories/releases/" }
     }
-}
 
-cobertura {
-    coberturaVersion = '2.1.1'
-    coverageFormats = ['xml', 'html']
-    coverageIgnoreTrivial = true
-    coverageReportDir = file("${buildDir}/reports/cobertura")
+    if (!"${project}".contains("android")) {
 
-    rootProject.subprojects.each {
-        coverageDirs << file("${it.name}/build/classes/main")
+        apply from: "${rootProject.rootDir}/gradle/plugins.gradle"
+        apply from: "${rootProject.rootDir}/gradle/subprojects-plugins.gradle"
     }
 }
 
 project(":core") {
     apply plugin: "java"
-//    apply from: "${rootProject.rootDir}/gradle/plugins.gradle"
 
     dependencies {
         compile project(":client")
@@ -150,14 +144,11 @@ project(":android") {
 }
 
 subprojects {
-    if (!"${project}".contains("android")) {
-        apply plugin: 'net.saliman.cobertura'
-        test.finalizedBy {project.tasks.cobertura}
-        apply from: "${rootProject.rootDir}/gradle/subprojects-plugins.gradle"
-    }
+
 }
 
 tasks.eclipse.doLast {
     delete ".project"
 }
 
+test.finalizedBy {project.tasks.cobertura}

--- a/build.gradle
+++ b/build.gradle
@@ -43,21 +43,19 @@ allprojects {
     }
 }
 
+cobertura {
+    coberturaVersion = '2.1.1'
+    coverageFormats = ['xml', 'html']
+    coverageIgnoreTrivial = true
+    coverageReportDir = file("${buildDir}/reports/cobertura")
+
+    rootProject.subprojects.each {
+        coverageDirs << file("${it.name}/build/classes/main")
+    }
+}
+
 project(":core") {
     apply plugin: "java"
-    apply plugin: 'net.saliman.cobertura'
-    cobertura {
-        coberturaVersion = '2.1.1'
-        coverageFormats = ['xml', 'html']
-        coverageIgnoreTrivial = true
-        coverageReportDir = file("${buildDir}/reports/cobertura")
-
-        rootProject.subprojects.each {
-            coverageDirs << file("${it.name}/build/classes/main")
-        }
-    }
-
-    test.finalizedBy(project.tasks.cobertura)
 //    apply from: "${rootProject.rootDir}/gradle/plugins.gradle"
 
     dependencies {
@@ -75,19 +73,6 @@ project(":core") {
 
 project(":desktop") {
     apply plugin: "java"
-    apply plugin: 'net.saliman.cobertura'
-    cobertura {
-        coberturaVersion = '2.1.1'
-        coverageFormats = ['xml', 'html']
-        coverageIgnoreTrivial = true
-        coverageReportDir = file("${buildDir}/reports/cobertura")
-
-        rootProject.subprojects.each {
-            coverageDirs << file("${it.name}/build/classes/main")
-        }
-    }
-
-    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":core")
@@ -100,19 +85,6 @@ project(":desktop") {
 
 project(":server") {
     apply plugin: "java"
-    apply plugin: 'net.saliman.cobertura'
-    cobertura {
-        coberturaVersion = '2.1.1'
-        coverageFormats = ['xml', 'html']
-        coverageIgnoreTrivial = true
-        coverageReportDir = file("${buildDir}/reports/cobertura")
-
-        rootProject.subprojects.each {
-            coverageDirs << file("${it.name}/build/classes/main")
-        }
-    }
-
-    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":data_structures")
@@ -127,19 +99,6 @@ project(":server") {
 
 project(":client") {
     apply plugin: "java"
-    apply plugin: 'net.saliman.cobertura'
-    cobertura {
-        coberturaVersion = '2.1.1'
-        coverageFormats = ['xml', 'html']
-        coverageIgnoreTrivial = true
-        coverageReportDir = file("${buildDir}/reports/cobertura")
-
-        rootProject.subprojects.each {
-            coverageDirs << file("${it.name}/build/classes/main")
-        }
-    }
-
-    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         compile project(":server")
@@ -153,19 +112,6 @@ project(":client") {
 
 project(":data_structures") {
     apply plugin: "java"
-    apply plugin: 'net.saliman.cobertura'
-    cobertura {
-        coberturaVersion = '2.1.1'
-        coverageFormats = ['xml', 'html']
-        coverageIgnoreTrivial = true
-        coverageReportDir = file("${buildDir}/reports/cobertura")
-
-        rootProject.subprojects.each {
-            coverageDirs << file("${it.name}/build/classes/main")
-        }
-    }
-
-    test.finalizedBy(project.tasks.cobertura)
 
     dependencies {
         testCompile "junit:junit:$junitVersion"
@@ -205,6 +151,8 @@ project(":android") {
 
 subprojects {
     if (!"${project}".contains("android")) {
+        apply plugin: 'net.saliman.cobertura'
+        test.finalizedBy {project.tasks.cobertura}
         apply from: "${rootProject.rootDir}/gradle/subprojects-plugins.gradle"
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,6 @@ apply plugin: "java"
 sourceSets.main.java.srcDirs = ["src/"]
 sourceSets.test.java.srcDirs = ["test/"]
 
-
 eclipse.project {
     name = appName + "-core"
 }

--- a/desktop/src/cg/group4/desktop/DesktopLauncher.java
+++ b/desktop/src/cg/group4/desktop/DesktopLauncher.java
@@ -18,7 +18,6 @@ public class DesktopLauncher {
      * Uses the Aspect enum to determine what height and width to use for testing the screen on desktop.
      */
     public static final Aspect ASPECT = Aspect.RATIO9_16;
-
     /**
      * Starts the application.
      *

--- a/gradle/plugins.gradle
+++ b/gradle/plugins.gradle
@@ -7,11 +7,10 @@ cobertura {
     coverageIgnoreTrivial = true
     coverageReportDir = file("${buildDir}/reports/cobertura")
 
-    rootProject.subprojects.each {
-        coverageDirs << file("${it.name}/build/classes/main")
-    }
+//    rootProject.subprojects.each {
+//        coverageDirs << file("${it.name}/build/classes/main")
+//    }
 }
-
 
 test.finalizedBy(project.tasks.cobertura)
 


### PR DESCRIPTION
Every individual project now generates a Cobertura report. For some reason I didn't get it to work for the main project to combine everything. I'd suggest we look into this at a later point, but for now go with this.